### PR TITLE
Allow targeted breadcrumb generation using different routes

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -53,9 +53,21 @@ class Manager
      */
     public function current($parameters = null): Collection
     {
+        return $this->generate(Route::current()->getName(), $parameters);
+    }
+
+    /**
+     * @param $route
+     * @param null $parameters
+     *
+     * @return Collection
+     * @throws \Throwable
+     */
+    public function generate($route, $parameters = null): Collection
+    {
         $parameters = Arr::wrap($parameters);
 
-        return $this->generator->generate($parameters);
+        return $this->generator->generate($route, $parameters);
     }
 
     /**

--- a/src/Trail.php
+++ b/src/Trail.php
@@ -69,16 +69,14 @@ class Trail
      * @return \Illuminate\Support\Collection
      * @throws \Throwable
      */
-    public function generate(array $parameters = null): Collection
+    public function generate($route, array $parameters = null): Collection
     {
-        $route = Route::current();
-
         $parameters = empty($parameters)
             ? $route->parameters()
             : $parameters;
 
-        if ($route && $this->registrar->has($route->getName())) {
-            $this->call($route->getName(), $parameters);
+        if ($route && $this->registrar->has($route)) {
+            $this->call($route, $parameters);
         }
 
         return $this->breadcrumbs;


### PR DESCRIPTION
This is a feature that the original package https://github.com/davejamesmiller/laravel-breadcrumbs allowed for, that is really useful when multiple breadcrumbs can be shared across several routes.