### PR TITLE
Added macroable trait

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -8,9 +8,12 @@ use Closure;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Traits\Macroable;
 
 class Manager
 {
+    use Macroable;
+
     /**
      * The breadcrumb generator.
      *


### PR DESCRIPTION
Made Manager class macroable to have the ability to add additional functionality to the class. Useful if you wish to mimic davejamesmiller/laravel-breadcrumbs as close as possible by adding render method for example.
