### PR TITLE
Added blade component

### DIFF
--- a/src/BreadcrumbsComponent.php
+++ b/src/BreadcrumbsComponent.php
@@ -17,7 +17,7 @@ class BreadcrumbsComponent extends Component
     /**
      * @var string|null
      */
-    public $name;
+    public $route;
 
     /**
      * @var mixed|null
@@ -38,21 +38,21 @@ class BreadcrumbsComponent extends Component
      * Create a new component instance.
      *
      * @param Manager     $manager
-     * @param string|null $name
+     * @param string|null $route
      * @param mixed|null  $parameters
      * @param string|null $class
      * @param string|null $active
      */
     public function __construct(
         Manager $manager,
-        string $name = null,
+        string $route = null,
         $parameters = null,
         string $class = null,
         string $active = null
     )
     {
         $this->breadcrumbs = $manager;
-        $this->name = $name;
+        $this->route = $route;
         $this->parameters = $parameters;
         $this->class = $class;
         $this->active = $active;
@@ -64,8 +64,8 @@ class BreadcrumbsComponent extends Component
      */
     public function generate(): Collection
     {
-        if ($this->name !== null) {
-            return $this->breadcrumbs->generate($this->name, $this->parameters);
+        if ($this->route !== null) {
+            return $this->breadcrumbs->generate($this->route, $this->parameters);
         }
 
         return $this->breadcrumbs->current($this->parameters);
@@ -78,7 +78,7 @@ class BreadcrumbsComponent extends Component
      */
     public function render()
     {
-        return $this->breadcrumbs->has($this->name)
+        return $this->breadcrumbs->has($this->route)
             ? view('breadcrumbs::breadcrumbs')
             : '';
     }

--- a/src/BreadcrumbsComponent.php
+++ b/src/BreadcrumbsComponent.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tabuna\Breadcrumbs;
+
+use Illuminate\View\Component;
+use Illuminate\Support\Collection;
+
+class BreadcrumbsComponent extends Component
+{
+    /**
+     * @var Manager
+     */
+    public $breadcrumbs;
+
+    /**
+     * @var string|null
+     */
+    public $name;
+
+    /**
+     * @var mixed|null
+     */
+    public $parameters;
+
+    /**
+     * @var string|null
+     */
+    public $class;
+
+    /**
+     * @var string|null
+     */
+    public $active;
+
+    /**
+     * Create a new component instance.
+     *
+     * @param Manager     $manager
+     * @param string|null $name
+     * @param mixed|null  $parameters
+     * @param string|null $class
+     * @param string|null $active
+     */
+    public function __construct(
+        Manager $manager,
+        string $name = null,
+        $parameters = null,
+        string $class = null,
+        string $active = null
+    )
+    {
+        $this->breadcrumbs = $manager;
+        $this->name = $name;
+        $this->parameters = $parameters;
+        $this->class = $class;
+        $this->active = $active;
+    }
+
+    /**
+     * @return Collection
+     * @throws \Throwable
+     */
+    public function generate(): Collection
+    {
+        if ($this->name !== null) {
+            return $this->breadcrumbs->generate($this->name, $this->parameters);
+        }
+
+        return $this->breadcrumbs->current($this->parameters);
+    }
+
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\View\View|string
+     */
+    public function render()
+    {
+        return $this->breadcrumbs->has($this->name)
+            ? view('breadcrumbs::breadcrumbs')
+            : '';
+    }
+}

--- a/src/BreadcrumbsServiceProvider.php
+++ b/src/BreadcrumbsServiceProvider.php
@@ -5,11 +5,20 @@ declare(strict_types=1);
 namespace Tabuna\Breadcrumbs;
 
 use Illuminate\Routing\Route;
+use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
 use function Opis\Closure\serialize;
 
 class BreadcrumbsServiceProvider extends ServiceProvider
 {
+    /**
+     * Bootstrap your package's services.
+     */
+    public function boot()
+    {
+        Blade::component('tabuna-breadcrumbs', BreadcrumbsComponent::class);
+    }
+
     /**
      * Register the service provider.
      *
@@ -18,6 +27,7 @@ class BreadcrumbsServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->singleton(Manager::class);
+        $this->loadViewsFrom(__DIR__ . '/../views', 'breadcrumbs');
 
         \Illuminate\Support\Facades\Route::middlewareGroup('breadcrumbs', [
             BreadcrumbsMiddleware::class,

--- a/tests/ComponentTest.php
+++ b/tests/ComponentTest.php
@@ -1,0 +1,67 @@
+<?php
+
+
+namespace Tabuna\Breadcrumbs\Tests;
+
+use Illuminate\Support\Facades\Route;
+use Illuminate\Testing\TestResponse;
+use Tabuna\Breadcrumbs\Trail;
+
+class ComponentTest extends TestCase
+{
+
+    public function testSimple(): void
+    {
+        $this->getComponent('simple')->assertSee('Home');
+    }
+
+    public function testClass(): void
+    {
+        $this->getComponent('class')
+            ->assertSee('Home')
+            ->assertSee('<li class="item">', false)
+            ->assertSee('<li class="item active">', false);
+    }
+
+    public function testRoute(): void
+    {
+        $this->getComponent('route')
+            ->assertSee('Static Page');
+    }
+
+    public function testParameters(): void
+    {
+        $this->getComponent('parameters')
+            ->assertSee('value 1')
+            ->assertSee('value 2')
+            ->assertSee('value 3');
+    }
+
+    /**
+     * @param string $template
+     *
+     * @return TestResponse
+     */
+    protected function getComponent(string $template): TestResponse
+    {
+        Route::get('static', function (string $view) {
+        })
+            ->name('static')
+            ->breadcrumbs(function (Trail $trail) {
+                return $trail->push('Static Page');
+            });
+
+        Route::get('component/{view}', function (string $view) {
+            return view("test_breadcrumbs::$view");
+        })
+            ->name('breadcrumbs.components')
+            ->breadcrumbs(function (Trail $trail, $value = null, $value2 = null) {
+                return $trail
+                    ->push('Home')
+                    ->push('Arguments', $value)
+                    ->push('Arguments2', $value2);
+            });
+
+        return $this->get("component/$template");
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -18,7 +18,8 @@ class TestCase extends BaseCase
     protected function getPackageProviders($app): array
     {
         return [
-            BreadcrumbsServiceProvider::class
+            BreadcrumbsServiceProvider::class,
+            TestServiceProvider::class
         ];
     }
 

--- a/tests/TestServiceProvider.php
+++ b/tests/TestServiceProvider.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tabuna\Breadcrumbs\Tests;
+
+use Illuminate\Support\ServiceProvider;
+
+class TestServiceProvider extends ServiceProvider
+{
+    /**
+     * Register the service provider.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->loadViewsFrom(__DIR__ . '/views', 'test_breadcrumbs');
+    }
+}

--- a/tests/views/class.blade.php
+++ b/tests/views/class.blade.php
@@ -1,0 +1,4 @@
+<x-tabuna-breadcrumbs
+  class="item"
+  active="active"
+/>

--- a/tests/views/parameters.blade.php
+++ b/tests/views/parameters.blade.php
@@ -1,0 +1,3 @@
+<x-tabuna-breadcrumbs
+    parameters="['value 1', 'value 2', 'value 3']"
+/>

--- a/tests/views/route.blade.php
+++ b/tests/views/route.blade.php
@@ -1,3 +1,3 @@
 <x-tabuna-breadcrumbs
-    name="static"
+    route="static"
 />

--- a/tests/views/route.blade.php
+++ b/tests/views/route.blade.php
@@ -1,0 +1,3 @@
+<x-tabuna-breadcrumbs
+    name="static"
+/>

--- a/tests/views/simple.blade.php
+++ b/tests/views/simple.blade.php
@@ -1,0 +1,1 @@
+<x-tabuna-breadcrumbs/>

--- a/views/breadcrumbs.blade.php
+++ b/views/breadcrumbs.blade.php
@@ -1,0 +1,13 @@
+@foreach ($generate() as $crumbs)
+    @if ($crumbs->url() && !$loop->last)
+        <li class="{{$class}}">
+            <a href="{{ $crumbs->url() }}">
+                {{ $crumbs->title() }}
+            </a>
+        </li>
+    @else
+        <li class="{{$class}} {{$active}}">
+            {{ $crumbs->title() }}
+        </li>
+    @endif
+@endforeach


### PR DESCRIPTION
Hey. I think it would be nice to have a component for determining breadcrumbs directly from the package.


It would be a straightforward definition, for example:
```blade
<x-tabuna-breadcrumbs/>
```

To define classes of list items, you can specify:
```blade
<x-tabuna-breadcrumbs
  class="item"
  active="active"
/>
```

You can also pass parameters:
```blade
<x-tabuna-breadcrumbs
    parameters="['value 1', 'value 2', 'value 3']"
/>
```

And call named routes explicitly:
```blade
<x-tabuna-breadcrumbs
    route="static"
/>
```