### PR TITLE
refs #15 Removed white space

### DIFF
--- a/views/breadcrumbs.blade.php
+++ b/views/breadcrumbs.blade.php
@@ -1,13 +1,9 @@
 @foreach ($generate() as $crumbs)
     @if ($crumbs->url() && !$loop->last)
         <li class="{{$class}}">
-            <a href="{{ $crumbs->url() }}">
-                {{ $crumbs->title() }}
-            </a>
+            <a href="{{ $crumbs->url() }}">{{ $crumbs->title() }}</a>
         </li>
     @else
-        <li class="{{$class}} {{$active}}">
-            {{ $crumbs->title() }}
-        </li>
+        <li class="{{$class}} {{$active}}">{{ $crumbs->title() }}</li>
     @endif
 @endforeach


### PR DESCRIPTION
refs #15 


Before:
```php
<?php $__currentLoopData = $generate(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $crumbs): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>
    <?php if($crumbs->url() && !$loop->last): ?>
        <li class="<?php echo e($class); ?>">
            <a href="<?php echo e($crumbs->url()); ?>">
                <?php echo e($crumbs->title()); ?>

            </a>
        </li>
    <?php else: ?>
        <li class="<?php echo e($class); ?> <?php echo e($active); ?>">
            <?php echo e($crumbs->title()); ?>

        </li>
    <?php endif; ?>
<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>
```

After:
```php
<?php $__currentLoopData = $generate(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $crumbs): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>
    <?php if($crumbs->url() && !$loop->last): ?>
        <li class="<?php echo e($class); ?>">
            <a href="<?php echo e($crumbs->url()); ?>"><?php echo e($crumbs->title()); ?></a>
        </li>
    <?php else: ?>
        <li class="<?php echo e($class); ?> <?php echo e($active); ?>"><?php echo e($crumbs->title()); ?></li>
    <?php endif; ?>
<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>
```