### PR TITLE
[bug] Breadcrumbs::current() should return the same results when called multiple times  

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -22,6 +22,13 @@ class Manager
     protected $generator;
 
     /**
+     * The cached current breadcrumb trail.
+     *
+     * @var Collection
+     */
+    protected $cachedCurrentBreadcrumbs;
+
+    /**
      * Create the instance of the manager.
      *
      * @param Trail $generator
@@ -56,13 +63,17 @@ class Manager
      */
     public function current($parameters = null): Collection
     {
+        if ($this->cachedCurrentBreadcrumbs) {
+            return $this->cachedCurrentBreadcrumbs;
+        }
+
         $name = optional(Route::current())->getName();
 
         if ($name === null) {
             return collect();
         }
 
-        return $this->generate($name, $parameters);
+        return $this->cachedCurrentBreadcrumbs = $this->generate($name, $parameters);
     }
 
     /**

--- a/tests/BreadcrumbsTest.php
+++ b/tests/BreadcrumbsTest.php
@@ -44,7 +44,6 @@ class BreadcrumbsTest extends TestCase
     {
 
         Route::get('/', function () {
-
         })
             ->name('home')
             ->breadcrumbs(function (Trail $trail) {
@@ -254,5 +253,27 @@ class BreadcrumbsTest extends TestCase
         $count = $this->get('/times')->content();
 
         $this->assertEquals('1', $count);
+    }
+
+
+    public function testBreadcrumbsIdempotency(): void
+    {
+        Route::get('/breadcrumbs-home', function () {
+            Breadcrumbs::current();
+
+            return Breadcrumbs::current()->toJson();
+        })->name('breadcrumbs-home');
+
+        Breadcrumbs::for('breadcrumbs-home', function (Trail $trail) {
+            return $trail->push('Home', 'http://localhost/');
+        });
+
+        $this->get('/breadcrumbs-home')
+            ->assertExactJson([
+                [
+                    'title' => 'Home',
+                    'url'   => 'http://localhost/',
+                ],
+            ]);
     }
 }


### PR DESCRIPTION
This PR aims to resolve a bug where when trying to call `Breadcrumbs::current()` mutliple times in a page, adds another crumbs trail to the previous and returns that.

### Scenario

In [rappasoft/laravel-boilerplate](https://github.com/rappasoft/laravel-boilerplate) the `Breadcrumbs::current()` is being called in the `backend.includes.header` view and when we tried to call it again in another part of the page, it stacks the crumbs with the previous call.

```
// First call in `backend.includes.header`
Breadcrumbs::current() // returns [{"title":"Home","url":"http:\/\/localhost\/"}]

// Another call else where
Breadcrumbs::current() // returns [{"title":"Home","url":"http:\/\/localhost\/"},{"title":"Home","url":"http:\/\/localhost\/"}]
```

### Expectation 

`Breadcrumbs::current()` should return the same output every time it is called instead of stacking.