### PR TITLE
Replace opis/closure with laravel/serializable-closure

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
         }
     ],
     "require": {
+        "ext-json": "*",
         "laravel/framework": "^8.16",
-        "opis/closure": "^3.5",
-        "ext-json": "*"
+        "laravel/serializable-closure": "^1.0"
     },
     "require-dev": {
         "orchestra/testbench": "~6.0",
@@ -54,4 +54,3 @@
         "sort-packages": true
     }
 }
-

--- a/src/BreadcrumbsMiddleware.php
+++ b/src/BreadcrumbsMiddleware.php
@@ -8,8 +8,7 @@ use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
 use Illuminate\Routing\Router;
-use Opis\Closure\SerializableClosure;
-use function Opis\Closure\unserialize;
+use Laravel\SerializableClosure\SerializableClosure;
 
 class BreadcrumbsMiddleware
 {
@@ -55,19 +54,8 @@ class BreadcrumbsMiddleware
             ->each(function (Route $route) {
                 $serialize = $route->defaults[self::class];
 
-                // Check if a security provider was set
-                if (null !== $securityProvider = SerializableClosure::getSecurityProvider()) {
-                    // Don't worry about it, our closure will be executed locally
-                    SerializableClosure::removeSecurityProvider();
-                }
-
-                /** @var \Opis\Closure\SerializableClosure $callback */
+                /** @var SerializableClosure $callback */
                 $callback = unserialize($serialize);
-
-                // Restore the security provider, if any
-                if ($securityProvider !== null) {
-                    SerializableClosure::addSecurityProvider($securityProvider);
-                }
 
                 if (is_a($callback, SerializableClosure::class)) {
                     $callback = $callback->getClosure();

--- a/src/BreadcrumbsServiceProvider.php
+++ b/src/BreadcrumbsServiceProvider.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace Tabuna\Breadcrumbs;
 
+use Closure;
 use Illuminate\Routing\Route;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
-use function Opis\Closure\serialize;
+use Laravel\SerializableClosure\SerializableClosure;
 
 class BreadcrumbsServiceProvider extends ServiceProvider
 {
@@ -37,9 +38,10 @@ class BreadcrumbsServiceProvider extends ServiceProvider
             return;
         }
 
-        Route::macro('breadcrumbs', function (callable $closure) {
+        Route::macro('breadcrumbs', function (Closure $closure) {
+            /** @var Route $this */
             $this->middleware('breadcrumbs')
-                ->defaults(BreadcrumbsMiddleware::class, serialize($closure));
+                ->defaults(BreadcrumbsMiddleware::class, serialize(new SerializableClosure($closure)));
 
             return $this;
         });


### PR DESCRIPTION
Closes #30.

- The type-hint change from `callable` to `Closure` in the `Route` macro is technically a breaking change, but the chances somebody is using anything but a `Closure` as a `callable` is _very very slim_. The charm of this package is the ability to use Closures in the route definition. 🤙🏻 (This is needed because Laravel's `SerializableClosure` only accepts actual `Closure`s.)
- Laravel now handles the security in `EncryptionServiceProvider`, it is probably safe to omit the temporary security provider overrides in the middleware.
- Since no behavior was altered at all, I did not add/remove any tests.