### PR TITLE
Remove support php 7.3

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.0, 7.4, 7.3]
+        php: [8.0, 7.4]
         laravel: [8.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         }
     ],
     "require": {
+        "php": "^7.4|^8.0",
         "ext-json": "*",
         "laravel/framework": "^8.16",
         "laravel/serializable-closure": "^1.0"

--- a/src/BreadcrumbsMiddleware.php
+++ b/src/BreadcrumbsMiddleware.php
@@ -57,11 +57,7 @@ class BreadcrumbsMiddleware
                 /** @var SerializableClosure $callback */
                 $callback = unserialize($serialize);
 
-                if (is_a($callback, SerializableClosure::class)) {
-                    $callback = $callback->getClosure();
-                }
-
-                $this->breadcrumbs->for($route->getName(), $callback);
+                $this->breadcrumbs->for($route->getName(), $callback->getClosure());
             });
 
         optional($request->route())->forgetParameter(self::class);


### PR DESCRIPTION
Thanks to work #31, the package was transferred to `laravel/serializable-closure`, unfortunately, it does [not work for PHP 7.3](https://github.com/laravel/serializable-closure/issues/21), so we should specify the version in `composer.json`.