### PR TITLE
refs #49 Added `escape`  parameter to component

### DIFF
--- a/src/BreadcrumbsComponent.php
+++ b/src/BreadcrumbsComponent.php
@@ -10,65 +10,29 @@ use Illuminate\View\Component;
 class BreadcrumbsComponent extends Component
 {
     /**
-     * @var Manager
-     */
-    public $breadcrumbs;
-
-    /**
-     * @var string|null
-     */
-    public $route;
-
-    /**
-     * @var mixed|null
-     */
-    public $parameters;
-
-    /**
-     * @var string|null
-     */
-    public $class;
-
-    /**
-     * @var string|null
-     */
-    public $active;
-
-    /**
      * Create a new component instance.
-     *
-     * @param Manager     $manager
-     * @param string|null $route
-     * @param mixed|null  $parameters
-     * @param string|null $class
-     * @param string|null $active
      */
     public function __construct(
-        Manager $manager,
-        string $route = null,
-        $parameters = null,
-        string $class = null,
-        string $active = null
-    )
-    {
-        $this->breadcrumbs = $manager;
-        $this->route = $route;
-        $this->parameters = $parameters;
-        $this->class = $class;
-        $this->active = $active;
-    }
+        public Manager $manager,
+        public ?string $route = null,
+        public $parameters = null,
+        public ?string $class = null,
+        public ?string $active = null,
+        public bool $escape = true,
+    ) {}
 
     /**
-     * @return Collection
      * @throws \Throwable
+     *
+     * @return Collection
      */
     public function generate(): Collection
     {
         if ($this->route !== null) {
-            return $this->breadcrumbs->generate($this->route, $this->parameters);
+            return $this->manager->generate($this->route, $this->parameters);
         }
 
-        return $this->breadcrumbs->current($this->parameters);
+        return $this->manager->current($this->parameters);
     }
 
     /**
@@ -78,7 +42,7 @@ class BreadcrumbsComponent extends Component
      */
     public function shouldRender(): bool
     {
-        return $this->breadcrumbs->has($this->route);
+        return $this->manager->has($this->route);
     }
 
     /**
@@ -89,5 +53,17 @@ class BreadcrumbsComponent extends Component
     public function render()
     {
         return view('breadcrumbs::breadcrumbs');
+    }
+
+    /**
+     * @param Crumb $crumb
+     *
+     * @return string|null
+     */
+    public function title(Crumb $crumb): ?string
+    {
+        $title = $crumb->title();
+
+        return $this->escape ? e($title) : $title;
     }
 }

--- a/tests/ComponentTest.php
+++ b/tests/ComponentTest.php
@@ -37,6 +37,19 @@ class ComponentTest extends TestCase
             ->assertSee('value 3');
     }
 
+    public function testEscapedHtmlIsRenderedAsText(): void
+    {
+        $this->getComponent('escaped')
+            ->assertSee('<strong>Important Notice</strong>')
+            ->assertDontSee('<strong>Important Notice</strong>', false);
+    }
+
+    public function testUnescapedHtmlIsRenderedAsHtml(): void
+    {
+        $this->getComponent('unescaped')
+            ->assertSee('<strong>Important Notice</strong>', false);
+    }
+
     /**
      * @param string $template
      *
@@ -59,7 +72,8 @@ class ComponentTest extends TestCase
                 return $trail
                     ->push('Home')
                     ->push('Arguments', $value)
-                    ->push('Arguments2', $value2);
+                    ->push('Arguments2', $value2)
+                    ->push('<strong>Important Notice</strong>');
             });
 
         return $this->get("component/$template");

--- a/tests/views/escaped.blade.php
+++ b/tests/views/escaped.blade.php
@@ -1,0 +1,3 @@
+<x-tabuna-breadcrumbs
+  :escape="true"
+/>

--- a/tests/views/unescaped.blade.php
+++ b/tests/views/unescaped.blade.php
@@ -1,0 +1,3 @@
+<x-tabuna-breadcrumbs
+  :escape="false"
+/>

--- a/views/breadcrumbs.blade.php
+++ b/views/breadcrumbs.blade.php
@@ -1,9 +1,13 @@
 @foreach ($generate() as $crumbs)
     @if ($crumbs->url() && !$loop->last)
-        <li class="{{$class}}">
-            <a href="{{ $crumbs->url() }}">{{ $crumbs->title() }}</a>
+        <li {{ $attributes->merge(['class' => $class]) }}>
+            <a href="{{ $crumbs->url() }}">
+                {!! $title($crumbs) !!}
+            </a>
         </li>
     @else
-        <li class="{{$class}} {{$active}}">{{ $crumbs->title() }}</li>
+        <li {{ $attributes->merge(['class' => $class. ' '. $active]) }}>
+            {!! $title($crumbs) !!}
+        </li>
     @endif
 @endforeach


### PR DESCRIPTION
Adds an `escape` parameter to the `<x-tabuna-breadcrumbs />` component. 
Setting `:escape="false"` disables HTML escaping for breadcrumb titles.

Example:

```blade
<x-tabuna-breadcrumbs :escape="false" />
```