### PR TITLE
Test breadcrumbs overwrite with null

### DIFF
--- a/src/BreadcrumbsMiddleware.php
+++ b/src/BreadcrumbsMiddleware.php
@@ -57,6 +57,10 @@ class BreadcrumbsMiddleware
                 /** @var SerializableClosure $callback */
                 $callback = unserialize($serialize);
 
+                if ($route->getName() === null) {
+                    return;
+                }
+
                 $this->breadcrumbs->for($route->getName(), $callback->getClosure());
             });
 

--- a/tests/BreadcrumbsTest.php
+++ b/tests/BreadcrumbsTest.php
@@ -197,6 +197,32 @@ class BreadcrumbsTest extends TestCase
         ]);
     }
 
+    public function testBreadcrumbsOverwriteWithNull(): void
+    {
+        $domains = [
+            '127.0.0.1',
+            'localhost',
+            'foo.com',
+            'bar.com',
+        ];
+
+        foreach ($domains as $domain) {
+            Route::domain($domain)
+                ->get('/overwrite', function () {
+                    return response()->json([
+                        'exist' => Breadcrumbs::has(),
+                    ]);
+                })
+                ->breadcrumbs(function (Trail $trail) {
+                    return $trail->push('overwrite');
+                });
+        }
+
+        $this->get('/overwrite')->assertJson([
+            'exist' => false,
+        ]);
+    }
+
     public function testBreadcrumbsCacheDefined(): void
     {
         Route::get('/breadcrumbs-home', function () {


### PR DESCRIPTION
`$route->getName()` can be null, so this ensures a null value isn't passed into `$this->breadcrumbs->for(...)`